### PR TITLE
close#11

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,7 +34,7 @@
 	gameState = "loading";
 
 	startingHp = 5;
-	numLevels = 6;
+	numLevels = 10;
 
 	shakeAmount = 0;
 	shakeX = 0;

--- a/js/map.js
+++ b/js/map.js
@@ -52,7 +52,7 @@ function randomPassableTile(){
 
 function generateMonsters(){
     monsters = [];
-    let numMonsters = level+1;
+    let numMonsters = level > 5 ? level+1 : 6;
     for(let i=0;i<numMonsters;i++){
         spawnMonster();
     }
@@ -60,7 +60,14 @@ function generateMonsters(){
 
 function spawnMonster(){
     // let monsterType = shuffle([Goose, Ant, Mushroom, Eater, Toast])[0];
-    let monsterType = shuffle([Rock, Paper, Scissors ,Rock_Plus, Paper_Plus, Scissors_Plus, Rock_Anti, Paper_Anti, Scissors_Anti])[0];
+    let monsterType = shuffle([Rock_Plus, Paper_Plus, Scissors_Plus, Rock_Anti, Paper_Anti, Scissors_Anti])[0];
     let monster = new monsterType(randomPassableTile());
     monsters.push(monster);
+}
+
+function spawnWeakMonster(){
+  // let monsterType = shuffle([Goose, Ant, Mushroom, Eater, Toast])[0];
+  let monsterType = shuffle([Rock, Paper, Scissors])[0];
+  let monster = new monsterType(randomPassableTile());
+  monsters.push(monster);
 }

--- a/js/map.js
+++ b/js/map.js
@@ -52,7 +52,7 @@ function randomPassableTile(){
 
 function generateMonsters(){
     monsters = [];
-    let numMonsters = level > 5 ? level+1 : 6;
+    const numMonsters = level > 5 ? level+1 : 6;
     for(let i=0;i<numMonsters;i++){
         spawnMonster();
     }
@@ -60,14 +60,19 @@ function generateMonsters(){
 
 function spawnMonster(){
     // let monsterType = shuffle([Goose, Ant, Mushroom, Eater, Toast])[0];
-    let monsterType = shuffle([Rock_Plus, Paper_Plus, Scissors_Plus, Rock_Anti, Paper_Anti, Scissors_Anti])[0];
-    let monster = new monsterType(randomPassableTile());
-    monsters.push(monster);
+  const monsterTypes = [Rock, Paper, Scissors, Rock_Plus, Paper_Plus, Scissors_Plus, Rock_Anti, Paper_Anti, Scissors_Anti];
+  const monsterType = randomMonsterType( monsterTypes );
+  const monster = new monsterType(randomPassableTile());
+  monsters.push(monster);
 }
 
-function spawnWeakMonster(){
-  // let monsterType = shuffle([Goose, Ant, Mushroom, Eater, Toast])[0];
-  let monsterType = shuffle([Rock, Paper, Scissors])[0];
-  let monster = new monsterType(randomPassableTile());
+function spawnWeakMonster(){  
+  const monsterTypes = [Rock, Paper, Scissors];
+  const monsterType = randomMonsterType( monsterTypes );
+  const monster = new monsterType(randomPassableTile());
   monsters.push(monster);
+}
+
+function randomMonsterType(monsterTypes) {
+  return shuffle(monsterTypes)[0]
 }

--- a/js/monster.js
+++ b/js/monster.js
@@ -10,6 +10,7 @@ class Monster{
         this.bonusAttack = 0;
         this.base_bonus = 0;
         this.anti_multiplier = 1;
+        this.rebirth = false;
     }
 
     heal(damage){
@@ -125,6 +126,7 @@ class Monster{
         this.dead = true;
         this.tile.monster = null;
         this.sprite = 1;
+        (this.rebirth && level > 6) && spawnMinion();
     }
 
     move(tile){
@@ -279,6 +281,7 @@ class Rock_Anti extends Monster{
         this.isRock = true;
         this.base_damage = 2;
         this.anti_multiplier = -1;
+        this.rebirth = true;
     }
     update(){ // rocks move slower
         let startedStunned = this.stunned;
@@ -295,6 +298,7 @@ class Paper_Anti extends Monster{
         this.isPaper = true;
         this.base_damage = 2;
         this.anti_multiplier = -1;
+        this.rebirth = true;
     }
 }
 
@@ -304,6 +308,7 @@ class Scissors_Anti extends Monster{
         this.isScissors = true;
         this.base_damage = 2;
         this.anti_multiplier = -1;
+        this.rebirth = true;
     }
     doStuff(){ // scissors move faster
         this.attackedThisTurn = false;


### PR DESCRIPTION
I updated the max level to 10, and made changes to the `die()`:
```
    die(){
        this.dead = true;
        this.tile.monster = null;
        this.sprite = 1;
        (this.rebirth && level > 6) && spawnMinion();
    }
```
Right now only the anti_monsters have the rebirth atribute, a normal monster will spawn in its place.
```
function spawnWeakMonster(){
  // let monsterType = shuffle([Goose, Ant, Mushroom, Eater, Toast])[0];
  let monsterType = shuffle([Rock, Paper, Scissors])[0];
  let monster = new monsterType(randomPassableTile());
  monsters.push(monster);
}
```